### PR TITLE
fix(deps): override brace-expansion to patched 5.0.7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
   },
   "overrides": {
     "@babel/core": "7.29.6",
+    "brace-expansion": "5.0.7",
     "markdown-it": "14.2.0",
     "vite": "8.0.16",
   },
@@ -276,7 +277,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   "overrides": {
     "@babel/core": "7.29.6",
     "vite": "8.0.16",
-    "markdown-it": "14.2.0"
+    "markdown-it": "14.2.0",
+    "brace-expansion": "5.0.7"
   }
 }


### PR DESCRIPTION
fix(deps): override brace-expansion to patched 5.0.7 (1 commit).

- fix(deps): override brace-expansion to patched 5.0.7

Refs #123
