### PR TITLE
docs(instructions): sync chat templates from dx (#138)

### DIFF
--- a/.github/instructions/commit.instructions.md
+++ b/.github/instructions/commit.instructions.md
@@ -1,9 +1,14 @@
 ---
-applyTo: "**/COMMIT_EDITMSG"
+applyTo: "**"
 description: "Guidelines for writing commit messages"
 ---
 
 # Commit Guidelines
+
+These rules apply to every commit however it is written — `git commit -m` in a terminal included,
+not just an editor session on `COMMIT_EDITMSG`. `dx git feature` enforces the header format on the
+PR title, which for a single-commit branch **is** that commit's subject, so a non-conforming header
+blocks the PR.
 
 **Default: Generate a single-line commit message (header only). Include body/footer only when
 explicitly requested.**

--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -13,7 +13,9 @@ instead of hand-writing the title/body — it pushes the current branch and crea
 PR into `--base` (default `development`) applying these exact rules, including the harvested
 `Closes`/`Refs` footer. It refuses to guess a title once a branch carries more than one commit (pass
 `--title`) since summarizing intent across commits needs judgement a script doesn't have; run with
-`--dry-run` to preview the title/body before pushing anything.
+`--dry-run` to preview the title/body before pushing anything. It also aborts, before any push, on a
+title that isn't a Conventional Commit header — for a single-commit branch that title is the
+commit's own subject, so fix it with `git commit --amend`, not `--title`.
 
 ## Title
 


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- docs(instructions): sync chat templates from dx (#138)